### PR TITLE
Add project config logic

### DIFF
--- a/pages/alpha/v3/search.tsx
+++ b/pages/alpha/v3/search.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react';
+import {
+  withProjectConfig,
+  getProjectConfigStaticProps,
+  ProjectConfigConsumerProps,
+} from '../../../src/config/withProjectConfig';
+
+type AlphaV3SearchPageProps = ProjectConfigConsumerProps<'appearance' | 'filters'>;
+
+const AlphaV3SearchPage: FC<AlphaV3SearchPageProps> = ({
+  PROJECT: {
+    appearance: { appName },
+  },
+}) => <h1>Hello world from {appName}</h1>;
+
+export default withProjectConfig<AlphaV3SearchPageProps>(AlphaV3SearchPage);
+
+export const getStaticProps = getProjectConfigStaticProps(['appearance']);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,9 @@
+import warszawaConfig from './warszawa';
+import { ProjectConfig } from './types';
+
+export const projectConfigs: ProjectConfig[] = [warszawaConfig];
+
+export const getProjectConfig = (): ProjectConfig =>
+  projectConfigs.find(
+    ({ projectId }) => projectId === 'WARSZAWA', // TODO: Use env var
+  ) as ProjectConfig;

--- a/src/config/projectConfigContext.ts
+++ b/src/config/projectConfigContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import { ProjectConfig } from './types';
+
+export const projectConfigContext = createContext<Partial<ProjectConfig>>({});
+
+export const ProjectConfigProvider = projectConfigContext.Provider;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,0 +1,19 @@
+export type FilterDefinition = {
+  key: string;
+  component: string; // TODO: More strict types
+  options?: any; // TODO: More strict types
+  validator: string; // TODO: More strict types
+  initialValue: string | unknown[];
+};
+
+export type FiltersConfig = FilterDefinition[];
+
+export interface AppearanceConfig {
+  appName: string;
+}
+
+export interface ProjectConfig {
+  projectId: string;
+  filters: FiltersConfig;
+  appearance: AppearanceConfig;
+}

--- a/src/config/warszawa/appearance.ts
+++ b/src/config/warszawa/appearance.ts
@@ -1,0 +1,7 @@
+import { AppearanceConfig } from '../types';
+
+const appearanceConfig: AppearanceConfig = {
+  appName: 'warszawa',
+};
+
+export default appearanceConfig;

--- a/src/config/warszawa/filters.ts
+++ b/src/config/warszawa/filters.ts
@@ -1,0 +1,192 @@
+import { FiltersConfig } from '../types';
+
+const filtersConfig: FiltersConfig = [
+  {
+    key: 'query',
+    component: 'text',
+    validator: 'string',
+    initialValue: '',
+    options: {
+      placeholder: 'Nazwa szkoły lub słowo kluczowe',
+      icon: 'BsSearch',
+    },
+  },
+  {
+    key: 'public',
+    component: 'dropdown',
+    validator: 'none',
+    initialValue: [],
+    options: {
+      title: 'Szkoła publiczna',
+      isMultipleChoice: false,
+      choices: [
+        {
+          value: true,
+          label: 'tak',
+        },
+        {
+          value: false,
+          label: 'nie',
+        },
+      ],
+    },
+  },
+  {
+    key: 'schoolType',
+    component: 'dropdown',
+    validator: 'none',
+    initialValue: [],
+    options: {
+      title: 'Typ szkoły',
+      isMultipleChoice: true,
+      choices: [
+        {
+          value: 'liceum ogólnokształcące',
+          label: 'liceum',
+        },
+        {
+          value: 'technikum',
+          label: 'technikum',
+        },
+        {
+          value: 'szkoła branżowa I stopnia',
+          label: 'szkoła branżowa',
+        },
+      ],
+    },
+  },
+  {
+    key: 'extendedSubjects',
+    component: 'dropdown',
+    validator: 'none',
+    initialValue: [],
+    options: {
+      title: 'Przedmioty rozszerzone',
+      isMultipleChoice: true,
+      choices: [
+        {
+          value: 'pol',
+          label: 'język polski',
+        },
+        {
+          value: 'hist',
+          label: 'historia',
+        },
+        {
+          value: 'wos',
+          label: 'WOS',
+        },
+        {
+          value: 'mat',
+          label: 'matematyka',
+        },
+        {
+          value: 'fiz',
+          label: 'fizyka',
+        },
+        {
+          value: 'inf',
+          label: 'informatyka',
+        },
+        {
+          value: 'chem',
+          label: 'chemia',
+        },
+        {
+          value: 'biol',
+          label: 'biologia',
+        },
+        {
+          value: 'geogr',
+          label: 'geografia',
+        },
+      ],
+    },
+  },
+  {
+    key: 'districts',
+    component: 'dropdown',
+    validator: 'none',
+    initialValue: [],
+    options: {
+      title: 'Dzielnica',
+      isMultipleChoice: true,
+      choices: [
+        {
+          value: 'Bemowo',
+          label: 'Bemowo',
+        },
+        {
+          value: 'Białołęka',
+          label: 'Białołęka',
+        },
+        {
+          value: 'Bielany',
+          label: 'Bielany',
+        },
+        {
+          value: 'Mokotów',
+          label: 'Mokotów',
+        },
+        {
+          value: 'Ochota',
+          label: 'Ochota',
+        },
+        {
+          value: 'Praga Południe',
+          label: 'Praga Południe',
+        },
+        {
+          value: 'Praga Północ',
+          label: 'Praga Północ',
+        },
+        {
+          value: 'Rembertów',
+          label: 'Rembertów',
+        },
+        {
+          value: 'Śródmieście',
+          label: 'Śródmieście',
+        },
+        {
+          value: 'Targówek',
+          label: 'Targówek',
+        },
+        {
+          value: 'Ursus',
+          label: 'Ursus',
+        },
+        {
+          value: 'Ursynów',
+          label: 'Ursynów',
+        },
+        {
+          value: 'Wawer',
+          label: 'Wawer',
+        },
+        {
+          value: 'Wesoła',
+          label: 'Wesoła',
+        },
+        {
+          value: 'Wilanów',
+          label: 'Wilanów',
+        },
+        {
+          value: 'Włochy',
+          label: 'Włochy',
+        },
+        {
+          value: 'Wola',
+          label: 'Wola',
+        },
+        {
+          value: 'Żoliborz',
+          label: 'Żoliborz',
+        },
+      ],
+    },
+  },
+];
+
+export default filtersConfig;

--- a/src/config/warszawa/index.ts
+++ b/src/config/warszawa/index.ts
@@ -1,0 +1,11 @@
+import { ProjectConfig } from '../types';
+import filters from './filters';
+import appearance from './appearance';
+
+const projectConfig: ProjectConfig = {
+  projectId: 'WARSZAWA',
+  filters,
+  appearance,
+};
+
+export default projectConfig;

--- a/src/config/withProjectConfig.tsx
+++ b/src/config/withProjectConfig.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react';
+import { GetStaticProps } from 'next';
+import { ProjectConfigProvider } from './projectConfigContext';
+import { ProjectConfig } from './types';
+import { getProjectConfig } from './index';
+
+export interface ProjectConfigConsumerProps<T extends keyof ProjectConfig> {
+  PROJECT: Pick<ProjectConfig, T>;
+}
+
+export const getProjectConfigStaticProps = (
+  projectConfigKeys: (keyof ProjectConfig)[],
+): GetStaticProps => () => {
+  const projectConfig = getProjectConfig();
+
+  const partialProjectConfig = Object.fromEntries(
+    projectConfigKeys.map((key) => [key, projectConfig[key]]),
+  );
+
+  return {
+    props: {
+      PROJECT: partialProjectConfig,
+    },
+  };
+};
+
+export const withProjectConfig = <T extends ProjectConfigConsumerProps<any>>(
+  WrappedComponent: FC<T>,
+): FC<T> => (props) => (
+  <ProjectConfigProvider value={props.PROJECT}>
+    <WrappedComponent {...props} />
+  </ProjectConfigProvider>
+);
+
+export default withProjectConfig;


### PR DESCRIPTION
By using getInitialProps we can later easily switch from SSG to SSR and also, as project configs grow, we can provide given page only with needed data.
